### PR TITLE
fix: Make default templates refer to GUI pages (DSP-763)

### DIFF
--- a/data/dasch_ark_registry.ini
+++ b/data/dasch_ark_registry.ini
@@ -17,19 +17,19 @@ KnoraResourceIri: http://rdfh.ch/$project_id/$resource_id
 KnoraProjectIri: http://rdfh.ch/projects/$project_id
 
 # A template for generating redirect URLs referring to Knora projects.
-KnoraProjectRedirectUrl: http://$host/admin/projects/$project_iri
+KnoraProjectRedirectUrl: http://$host/project/$project_id/info
 
 # A template for generating redirect URLs referring to Knora resources.
-KnoraResourceRedirectUrl: http://$host/v2/resources/$resource_iri
+KnoraResourceRedirectUrl: http://$host/resource/$resource_iri
 
 # A template for generating redirect URLs referring to versions of Knora resources.
-KnoraResourceVersionRedirectUrl: http://$host/v2/resources/$resource_iri?version=$timestamp
+KnoraResourceVersionRedirectUrl: http://$host/resource/$resource_iri?version=$timestamp
 
 # A template for generating redirect URLs referring to Knora values.
-KnoraValueRedirectUrl: http://$host/v2/values/$resource_iri/$value_id
+KnoraValueRedirectUrl: http://$host/value/$resource_iri/$value_id
 
 # A template for generating redirect URLs referring to versions of Knora values.
-KnoraValueVersionRedirectUrl: http://$host/v2/values/$resource_iri/$value_id?version=$timestamp
+KnoraValueVersionRedirectUrl: http://$host/value/$resource_iri/$value_id?version=$timestamp
 
 # A template for generating redirect URLs referring to resources stored on the PHP-based server.
 PhpResourceRedirectUrl: http://$host/resources/$resource_int_id

--- a/data/dasch_ark_registry.ini
+++ b/data/dasch_ark_registry.ini
@@ -58,43 +58,27 @@ Host: 0.0.0.0:3333
 
 [0101]
 Host: kv.unil.ch
-KnoraResourceRedirectUrl: http://$host/resource/$resource_iri
-KnoraResourceVersionRedirectUrl: http://$host/resource/$resource_iri?version=$timestamp
 
 [0103]
 Host: kv.unil.ch
-KnoraResourceRedirectUrl: http://$host/resource/$resource_iri
-KnoraResourceVersionRedirectUrl: http://$host/resource/$resource_iri?version=$timestamp
 
 [0105]
 Host: kv.unil.ch
-KnoraResourceRedirectUrl: http://$host/resource/$resource_iri
-KnoraResourceVersionRedirectUrl: http://$host/resource/$resource_iri?version=$timestamp
 
 [0107]
 Host: kv.unil.ch
-KnoraResourceRedirectUrl: http://$host/resource/$resource_iri
-KnoraResourceVersionRedirectUrl: http://$host/resource/$resource_iri?version=$timestamp
 
 [0108]
 Host: kv.unil.ch
-KnoraResourceRedirectUrl: http://$host/resource/$resource_iri
-KnoraResourceVersionRedirectUrl: http://$host/resource/$resource_iri?version=$timestamp
 
 [0110]
 Host: kv.unil.ch
-KnoraResourceRedirectUrl: http://$host/resource/$resource_iri
-KnoraResourceVersionRedirectUrl: http://$host/resource/$resource_iri?version=$timestamp
 
 [0111]
 Host: kv.unil.ch
-KnoraResourceRedirectUrl: http://$host/resource/$resource_iri
-KnoraResourceVersionRedirectUrl: http://$host/resource/$resource_iri?version=$timestamp
 
 [0112]
 Host: kv.unil.ch
-KnoraResourceRedirectUrl: http://$host/resource/$resource_iri
-KnoraResourceVersionRedirectUrl: http://$host/resource/$resource_iri?version=$timestamp
 
 ############################################################################
 # lumieres-lausanne
@@ -109,18 +93,12 @@ KnoraResourceVersionRedirectUrl: http://junipero.unil.ch:10080/resources/$resour
 
 [0114]
 Host: kv.unil.ch
-KnoraResourceRedirectUrl: http://$host/resource/$resource_iri
-KnoraResourceVersionRedirectUrl: http://$host/resource/$resource_iri?version=$timestamp
 
 [0115]
 Host: kv.unil.ch
-KnoraResourceRedirectUrl: http://$host/resource/$resource_iri
-KnoraResourceVersionRedirectUrl: http://$host/resource/$resource_iri?version=$timestamp
 
 [0116]
 Host: kv.unil.ch
-KnoraResourceRedirectUrl: http://$host/resource/$resource_iri
-KnoraResourceVersionRedirectUrl: http://$host/resource/$resource_iri?version=$timestamp
 
 
 ############################################################################
@@ -133,8 +111,6 @@ KnoraResourceVersionRedirectUrl: http://$host/resource/$resource_iri?version=$ti
 
 [0801]
 Host: beol.dasch.swiss
-KnoraResourceRedirectUrl: http://$host/resource/$resource_iri
-KnoraResourceVersionRedirectUrl: http://$host/resource/$resource_iri?version=$timestamp
 
 
 ############################################################################

--- a/tests/test_0001.tavern.yaml
+++ b/tests/test_0001.tavern.yaml
@@ -12,11 +12,10 @@ stages:
       method: GET
 
     # ...and the expected response code and body
-    # redirect_query_params: http://0.0.0.0:3333/v2/resources/http%3A%2F%2Frdfh.ch%2F0001%2Fcmfk1DMHRBiR4-_6HXpEFA
     response:
       status_code: 302
       headers:
-        location: http://0.0.0.0:3333/v2/resources/http%3A%2F%2Frdfh.ch%2F0001%2Fcmfk1DMHRBiR4-_6HXpEFA
+        location: http://0.0.0.0:3333/resource/http%3A%2F%2Frdfh.ch%2F0001%2Fcmfk1DMHRBiR4-_6HXpEFA
         
   - name: Call resolver for value
 
@@ -26,8 +25,7 @@ stages:
       method: GET
 
     # ...and the expected response code and body
-    # redirect_query_params: http://0.0.0.0:3333/v2/resources/http%3A%2F%2Frdfh.ch%2F0001%2Fcmfk1DMHRBiR4-_6HXpEFA/pLlW4ODASumZfZFbJdpw1g
     response:
       status_code: 302
       headers:
-        location: http://0.0.0.0:3333/v2/values/http%3A%2F%2Frdfh.ch%2F0001%2Fcmfk1DMHRBiR4-_6HXpEFA/pLlW4ODASumZfZFbJdpw1g
+        location: http://0.0.0.0:3333/value/http%3A%2F%2Frdfh.ch%2F0001%2Fcmfk1DMHRBiR4-_6HXpEFA/pLlW4ODASumZfZFbJdpw1g

--- a/tests/test_0101.tavern.yaml
+++ b/tests/test_0101.tavern.yaml
@@ -12,13 +12,12 @@ stages:
       method: GET
 
     # ...and the expected response code and body
-    # redirect_query_params: http://0.0.0.0:3333/v2/resources/http%3A%2F%2Frdfh.ch%2F0001%2Fcmfk1DMHRBiR4-_6HXpEFA
     response:
       status_code: 302
       headers:
         location: http://kv.unil.ch/resource/http%3A%2F%2Frdfh.ch%2F0101%2F-6IqRiuwQHGbHWuy2O8Bfg
 
-  - name: Call resolver with a versionned resource
+  - name: Call resolver with a versioned resource
 
     # Define the request to be made...
     request:
@@ -26,7 +25,6 @@ stages:
       method: GET
 
     # ...and the expected response code and body
-    # redirect_query_params: http://0.0.0.0:3333/v2/resources/http%3A%2F%2Frdfh.ch%2F0001%2Fcmfk1DMHRBiR4-_6HXpEFA
     response:
       status_code: 302
       headers:

--- a/tests/test_0103.tavern.yaml
+++ b/tests/test_0103.tavern.yaml
@@ -17,7 +17,7 @@ stages:
       headers:
         location: http://kv.unil.ch/resource/http%3A%2F%2Frdfh.ch%2F0103%2F-2snwE4TSvyzoG7-m-m9xA
 
-  - name: Call resolver with a versionned resource
+  - name: Call resolver with a versioned resource
 
     # Define the request to be made...
     request:

--- a/tests/test_0105.tavern.yaml
+++ b/tests/test_0105.tavern.yaml
@@ -17,7 +17,7 @@ stages:
       headers:
         location: http://kv.unil.ch/resource/http%3A%2F%2Frdfh.ch%2F0105%2F-2v7IubeSFWF-rU0G-XmXA
 
-  - name: Call resolver with a versionned resource
+  - name: Call resolver with a versioned resource
 
     # Define the request to be made...
     request:

--- a/tests/test_0107.tavern.yaml
+++ b/tests/test_0107.tavern.yaml
@@ -12,13 +12,12 @@ stages:
       method: GET
 
     # ...and the expected response code and body
-    # redirect_query_params: http://0.0.0.0:3333/v2/resources/http%3A%2F%2Frdfh.ch%2F0001%2Fcmfk1DMHRBiR4-_6HXpEFA
     response:
       status_code: 302
       headers:
         location: http://kv.unil.ch/resource/http%3A%2F%2Frdfh.ch%2F0107%2F-fAaoABiQGaLpvfagStamg
 
-  - name: Call resolver with a versionned resource
+  - name: Call resolver with a versioned resource
 
     # Define the request to be made...
     request:

--- a/tests/test_0108.tavern.yaml
+++ b/tests/test_0108.tavern.yaml
@@ -12,13 +12,12 @@
         method: GET
   
       # ...and the expected response code and body
-      # redirect_query_params: http://0.0.0.0:3333/v2/resources/http%3A%2F%2Frdfh.ch%2F0001%2Fcmfk1DMHRBiR4-_6HXpEFA
       response:
         status_code: 302
         headers:
           location: http://kv.unil.ch/resource/http%3A%2F%2Frdfh.ch%2F0108%2F-fAaoABiQGaLpvfagStamg
   
-    - name: Call resolver with a versionned resource
+    - name: Call resolver with a versioned resource
   
       # Define the request to be made...
       request:

--- a/tests/test_0110.tavern.yaml
+++ b/tests/test_0110.tavern.yaml
@@ -12,13 +12,12 @@ stages:
       method: GET
 
     # ...and the expected response code and body
-    # redirect_query_params: http://0.0.0.0:3333/v2/resources/http%3A%2F%2Frdfh.ch%2F0001%2Fcmfk1DMHRBiR4-_6HXpEFA
     response:
       status_code: 302
       headers:
         location: http://kv.unil.ch/resource/http%3A%2F%2Frdfh.ch%2F0110%2Fcmfk1DMHRBiR4-_6HXpEFA
 
-  - name: Call resolver with a versionned resource
+  - name: Call resolver with a versioned resource
 
     # Define the request to be made...
     request:

--- a/tests/test_0111.tavern.yaml
+++ b/tests/test_0111.tavern.yaml
@@ -12,13 +12,12 @@ stages:
       method: GET
 
     # ...and the expected response code and body
-    # redirect_query_params: http://0.0.0.0:3333/v2/resources/http%3A%2F%2Frdfh.ch%2F0001%2Fcmfk1DMHRBiR4-_6HXpEFA
     response:
       status_code: 302
       headers:
         location: http://kv.unil.ch/resource/http%3A%2F%2Frdfh.ch%2F0111%2Fcmfk1DMHRBiR4-_6HXpEFA
 
-  - name: Call resolver with a versionned resource
+  - name: Call resolver with a versioned resource
 
     # Define the request to be made...
     request:

--- a/tests/test_0112.tavern.yaml
+++ b/tests/test_0112.tavern.yaml
@@ -12,7 +12,6 @@ stages:
       method: GET
 
     # ...and the expected response code and body
-    # redirect_query_params: http://0.0.0.0:3333/v2/resources/http%3A%2F%2Frdfh.ch%2F0001%2Fcmfk1DMHRBiR4-_6HXpEFA
     response:
       status_code: 302
       headers:

--- a/tests/test_0113.tavern.yaml
+++ b/tests/test_0113.tavern.yaml
@@ -17,7 +17,7 @@ stages:
       headers:
         location: http://junipero.unil.ch:10080/resources/http%3A%2F%2Frdfh.ch%2F0113%2FAIae47_ST-q6uanBmib0Ww
 
-  - name: Call resolver with a versionned resource
+  - name: Call resolver with a versioned resource
 
     # Define the request to be made...
     request:

--- a/tests/test_0114.tavern.yaml
+++ b/tests/test_0114.tavern.yaml
@@ -12,13 +12,12 @@ stages:
       method: GET
 
     # ...and the expected response code and body
-    # redirect_query_params: http://0.0.0.0:3333/v2/resources/http%3A%2F%2Frdfh.ch%2F0001%2Fcmfk1DMHRBiR4-_6HXpEFA
     response:
       status_code: 302
       headers:
         location: http://kv.unil.ch/resource/http%3A%2F%2Frdfh.ch%2F0114%2Fcmfk1DMHRBiR4-_6HXpEFA
 
-  - name: Call resolver with a versionned resource
+  - name: Call resolver with a versioned resource
 
     # Define the request to be made...
     request:

--- a/tests/test_0801.tavern.yaml
+++ b/tests/test_0801.tavern.yaml
@@ -12,7 +12,6 @@ stages:
       method: GET
 
     # ...and the expected response code and body
-    # redirect_query_params: http://0.0.0.0:3333/v2/resources/http%3A%2F%2Frdfh.ch%2F0001%2Fcmfk1DMHRBiR4-_6HXpEFA
     response:
       status_code: 302
       headers:

--- a/tests/test_0803.tavern.yaml
+++ b/tests/test_0803.tavern.yaml
@@ -12,7 +12,6 @@ stages:
       method: GET
 
     # ...and the expected response code and body
-    # redirect_query_params: http://0.0.0.0:3333/v2/resources/http%3A%2F%2Frdfh.ch%2F0001%2Fcmfk1DMHRBiR4-_6HXpEFA
     response:
       status_code: 302
       headers:


### PR DESCRIPTION
- [x] Change default URL templates (including `KnoraProjectRedirectUrl`) so they refer to DSP-UI routes instead of to Knora API routes.
- [x] Use these defaults for projects that already had them configured.

Resolves [DSP-763](https://dasch.myjetbrains.com/youtrack/issue/DSP-763).
