### PR TITLE
Update shortcodes -0862- Gotthelf

### DIFF
--- a/data/dasch_ark_registry.ini
+++ b/data/dasch_ark_registry.ini
@@ -356,9 +356,9 @@ Host: app.dasch.swiss
 [0860]
 Host: app.dasch.swiss
 
-# Gotthelf (test)
+# Gotthelf
 [0862]
-Host: app.rdu-07.dasch.swiss
+Host: app.dasch.swiss
 
 # Gotthelf (test)
 [0210]


### PR DESCRIPTION
Hi, Daniela, I am updating the host to app.dasch.swiss, because before the short code was used in a testserver. 