### PR TITLE
Reroute default project ARKs to DPE

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ https://admin.dasch.swiss/resource/http:%2F%2Frdfh.ch%[$project_id]%2F[$resource
 The following example shows how to change the default behavior of project ARK redirects.
 
 An ARK of a project looks like this: `https://ark.dasch.swiss/ark:/72163/1/ABCD` for project with short code `ABCD`. Per
-default, it is redirected to `https://meta.dasch.swiss/projects/ABCD` (as defined in `data/dasch_ark_registry.ini`).
+default, it is redirected to `https://repository.dasch.swiss/dpe/projects/ABCD` (as defined in `data/dasch_ark_registry.ini`).
 
 This behavior can be changed for a project by either setting another host for the project ARK (variable `ProjectHost`
 in the file `data/dasch_ark_registry.ini`). For example:
@@ -130,11 +130,11 @@ in the file `data/dasch_ark_registry.ini`). For example:
 ```
 [ABCD]
 Host: admin.dasch.swiss
-ProjectHost: meta.dasch.swiss
+ProjectHost: my-project.example.org
 ```
 
-This would redirect the ARK `https://ark.dasch.swiss/ark:/72163/1/ABCD` to `https://meta.dasch.swiss/projects/ABCD`. So,
-only the host is changed.
+This would redirect the ARK `https://ark.dasch.swiss/ark:/72163/1/ABCD` to `https://my-project.example.org/dpe/projects/ABCD`.
+So, only the host is changed.
 
 Or you can set the variable `DSPProjectRedirectUrl` with your own pattern or a hard coded URL. For example:
 

--- a/data/dasch_ark_registry.ini
+++ b/data/dasch_ark_registry.ini
@@ -17,7 +17,7 @@ DSPResourceIri : http://rdfh.ch/$project_id/$resource_id
 DSPProjectIri : http://rdfh.ch/projects/$project_id
 
 # A template for generating redirect URLs referring to DSP projects.
-DSPProjectRedirectUrl : https://$project_host/projects/$project_id
+DSPProjectRedirectUrl : https://$project_host/dpe/projects/$project_id
 
 # A template for generating redirect URLs referring to DSP resources.
 DSPResourceRedirectUrl : https://$host/resource/$project_id/$resource_id
@@ -38,7 +38,7 @@ PhpResourceRedirectUrl : https://$host/resources/$resource_int_id
 PhpResourceVersionRedirectUrl : https://$host/resources/$resource_int_id?citdate=$timestamp
 
 # Default project host if no project host is specified
-ProjectHost : meta.dasch.swiss
+ProjectHost : repository.dasch.swiss
 
 
 ############################################################################

--- a/data/dasch_ark_registry_staging.ini
+++ b/data/dasch_ark_registry_staging.ini
@@ -17,7 +17,7 @@ DSPResourceIri : http://rdfh.ch/$project_id/$resource_id
 DSPProjectIri : http://rdfh.ch/projects/$project_id
 
 # A template for generating redirect URLs referring to DSP projects.
-DSPProjectRedirectUrl : https://$project_host/projects/$project_id
+DSPProjectRedirectUrl : https://$project_host/dpe/projects/$project_id
 
 # A template for generating redirect URLs referring to DSP resources.
 DSPResourceRedirectUrl : https://$host/resource/$project_id/$resource_id
@@ -38,7 +38,7 @@ PhpResourceRedirectUrl : https://$host/resources/$resource_int_id
 PhpResourceVersionRedirectUrl : https://$host/resources/$resource_int_id?citdate=$timestamp
 
 # Default project host if no project host is specified
-ProjectHost : meta.stage.dasch.swiss
+ProjectHost : repository.stage.dasch.swiss
 
 
 ############################################################################

--- a/tests/test_083C.tavern.yaml
+++ b/tests/test_083C.tavern.yaml
@@ -1,0 +1,16 @@
+---
+# Covers the default project ARK redirect (no per-project DSPProjectRedirectUrl
+# or ProjectHost override) — shortcode 083C falls through to the DEFAULT section.
+test_name: Resolve 083C project - default redirect to DPE
+
+stages:
+  - name: Call resolver
+
+    request:
+      url: http://0.0.0.0:3336/ark:/72163/1/083C
+      method: GET
+
+    response:
+      status_code: 302
+      headers:
+        location: https://repository.dasch.swiss/dpe/projects/083C


### PR DESCRIPTION
## Summary
- Change the default project ARK redirect target from `meta(.stage).dasch.swiss/projects/<id>` to `repository(.stage).dasch.swiss/dpe/projects/<id>` by updating `ProjectHost` and `DSPProjectRedirectUrl` in the `[DEFAULT]` section of both registry files.
- Per-project overrides (`[0801]` beol, `[0836]` Nietzsche, plus the staging-only overrides on `[081A]`, `[081B]`, `[0827]`) are unaffected — they set their own `DSPProjectRedirectUrl` and don't go through the default template.
- Update the README so the documented default URL and override example reflect the new behaviour.
- Add `tests/test_083C.tavern.yaml` covering the default project redirect, which previously had no test coverage. `083C` (`ehkka`) is a project that only sets `Host` and falls through to the DEFAULT section, so it exercises the new template end-to-end.

## Effect
- `https://ark.dasch.swiss/ark:/72163/1/083C` → `https://repository.dasch.swiss/dpe/projects/083C` (and analogously on stage).
- Resource ARKs are unaffected — only the project-level redirect template changed.

## Test plan
- [x] Local smoke test against `daschswiss/ark-resolver:v1.7.4` confirmed `302 → https://repository.dasch.swiss/dpe/projects/083C`.
- [ ] CI runs the full tavern suite (`make test`) on push, including the new `test_083C` case.
- [ ] After merge, sanity-check a real ARK redirect on prod and stage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)